### PR TITLE
test: 複数のNode.jsとViteバージョンに対する互換性テストの追加

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -48,7 +48,10 @@
       "mcp__ide__executeCode",
       "WebFetch(domain:github.com)",
       "Bash(actionlint:*)",
-      "Bash(act:*)"
+      "Bash(act:*)",
+      "Bash(gh run list:*)",
+      "Bash(gh run view:*)",
+      "Bash(git ls-tree:*)"
     ],
     "deny": [
       "Read(../**)",

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -46,7 +46,9 @@
       "Edit(./**)",
       "mcp__ide__getDiagnostics",
       "mcp__ide__executeCode",
-      "WebFetch(domain:github.com)"
+      "WebFetch(domain:github.com)",
+      "Bash(actionlint:*)",
+      "Bash(act:*)"
     ],
     "deny": [
       "Read(../**)",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 8.10.0
+          run_install: false
 
       - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
@@ -69,12 +69,12 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 8.10.0
+          run_install: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version-file: '.node-version'
           cache: 'pnpm'
 
       - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   test:
@@ -50,6 +51,14 @@ jobs:
 
       - name: Run test coverage
         run: pnpm test:coverage
+
+      - name: Setup LCOV
+        if: matrix.os == 'ubuntu-latest'
+        uses: hrishikesh-kadam/setup-lcov@v1
+
+      - name: Coverage Report
+        if: matrix.os == 'ubuntu-latest'
+        uses: k1LoW/octocov-action@v1
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v4
         with:
           version: 8.10.0
 
@@ -67,7 +67,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v4
         with:
           version: 8.10.0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,75 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+      - 'test/**'
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        node-version: [22, 24]
+        vite-version: [6, 7]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 8.10.0
+
+      - name: Setup Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Vite ${{ matrix.vite-version }}
+        run: pnpm add -D vite@^${{ matrix.vite-version }}
+
+      - name: Build
+        run: pnpm build
+
+      - name: Run tests
+        run: pnpm test
+
+      - name: Run test coverage
+        run: pnpm test:coverage
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 8.10.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Type check
+        run: pnpm tsc --noEmit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install
 
       - name: Install Vite ${{ matrix.vite-version }}
         run: pnpm add -D vite@^${{ matrix.vite-version }}
@@ -78,7 +78,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install
 
       - name: Type check
         run: pnpm tsc --noEmit

--- a/package.json
+++ b/package.json
@@ -47,10 +47,10 @@
   "homepage": "https://github.com/memorylovers/vite-plugin-auto-line-ending#readme",
   "funding": "https://github.com/sponsors/memory-lovers",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "peerDependencies": {
-    "vite": "^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+    "vite": "^6.0.0 || ^7.0.0"
   },
   "devDependencies": {
     "@types/node": "^24.0.12",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,14 +6,15 @@
     "esModuleInterop": true,
     "strict": true,
     "resolveJsonModule": true,
+    "skipLibCheck": true,
     "types": [
       "node",
       "vitest/globals"
-    ],
+    ]
   },
   "include": [
     "src",
     "tests",
-    "package.json",
+    "package.json"
   ]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,5 +4,9 @@ export default defineConfig({
   test: {
     globals: true,
     silent: false,
+    coverage: {
+      reporter: ['text', 'lcov', 'html'],
+      reportsDirectory: './coverage',
+    },
   },
 });


### PR DESCRIPTION
## 概要
- 異なるバージョンとプラットフォームでのマトリックステスト用のGitHub Actions CIワークフローを追加
- Node.jsエンジン要件を >=20.0.0 から >=22.0.0 に更新
- Vite peerDependencyをv6とv7のみサポートするように更新

## テスト計画
- [x] マトリックステスト設定でCIワークフローを作成
- [x] actionlintでワークフロー構文を検証
- [x] actでワークフローをローカルテスト（ドライラン）
- [ ] PRでGitHub Actionsが実行され、すべてのマトリックスの組み合わせを検証

## 関連
Closes #1